### PR TITLE
feat(site): refresh landing — AI, jobs, iOS scan, roadmap, comparison

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const {
-  title = 'Librarium — self-hosted library tracker',
+  title = 'Librarium · self-hosted library tracker',
   description = 'Self-hosted, privacy-focused library tracker for books, manga, comics, and more. Cross-platform API, web, and iOS clients.',
 } = Astro.props;
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,28 +6,44 @@ const asset = (path: string) => `${base.replace(/\/$/, '')}/${path.replace(/^\//
 
 const features = [
   {
+    icon: 'server',
     title: 'Self-hosted, always',
     body: 'Runs on your infrastructure in Docker or Kubernetes. No telemetry. No external data calls unless you ask for a metadata lookup.',
   },
   {
+    icon: 'users',
     title: 'Multi-library, multi-user',
-    body: 'A single instance hosts independent libraries — shared household, personal collection, tech manuals — with per-library roles.',
+    body: 'A single instance hosts independent libraries (shared household, personal collection, tech manuals) with per-library roles.',
   },
   {
+    icon: 'book',
     title: 'Print-first catalog',
     body: 'FRBR-style work/edition model tracks physical books, manga, comics, magazines, and technical documents without schema gymnastics.',
   },
   {
-    title: 'Bring your own storage',
-    body: 'For ebooks and PDFs, Librarium stores a path reference — your files stay where you put them.',
+    icon: 'sparkles',
+    title: 'Bring your own AI',
+    body: 'Opt-in reading suggestions backed by Ollama, Osaurus, OpenAI, or Anthropic. Pick your provider and model. Run locally or ship it to the cloud, your call.',
   },
   {
+    icon: 'clock',
+    title: 'Scheduled work, observable',
+    body: 'Cover backfills, metadata refreshes, and AI runs all live on a single cron-driven jobs page. Run on demand, inspect history, or let it tick quietly.',
+  },
+  {
+    icon: 'folder',
+    title: 'Bring your own storage',
+    body: 'For ebooks and PDFs, Librarium stores a path reference. Your files stay where you put them.',
+  },
+  {
+    icon: 'devices',
     title: 'Cross-platform',
     body: 'Go API, React web UI, and a native SwiftUI iOS app (TestFlight today, App Store soon).',
   },
   {
+    icon: 'code',
     title: 'Open source',
-    body: 'Apache 2.0. Ship patches, file issues, or fork it — each client lives in its own repo and ships on its own cadence.',
+    body: 'Apache 2.0. Ship patches, file issues, or fork it. Each client lives in its own repo and ships on its own cadence.',
   },
 ];
 
@@ -65,7 +81,9 @@ const repos = [
         <span class="text-lg font-semibold tracking-tight text-white">Librarium</span>
       </a>
       <div class="flex items-center gap-6 text-sm">
+        <a href="#compare" class="text-slate-300 transition hover:text-white">Compare</a>
         <a href="#screenshots" class="text-slate-300 transition hover:text-white">Screenshots</a>
+        <a href="#roadmap" class="text-slate-300 transition hover:text-white">Roadmap</a>
         <a
           href="https://fireball1725.github.io/librarium-api/"
           class="text-slate-300 transition hover:text-white"
@@ -96,9 +114,17 @@ const repos = [
         height="96"
         class="mb-8 h-20 w-20 drop-shadow-[0_0_24px_rgba(79,70,229,0.5)] sm:h-24 sm:w-24"
       />
-      <p class="text-sm font-semibold tracking-widest text-indigo-300 uppercase">
-        Librarium
-      </p>
+      <div class="flex flex-wrap items-center gap-3">
+        <p class="text-sm font-semibold tracking-widest text-indigo-300 uppercase">
+          Librarium
+        </p>
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-0.5 text-xs font-semibold tracking-wide text-amber-300 uppercase"
+        >
+          <span class="h-1.5 w-1.5 rounded-full bg-amber-400"></span>
+          Early beta
+        </span>
+      </div>
       <h1 class="mt-4 text-4xl font-bold tracking-tight text-white sm:text-6xl">
         Catalog your shelves.<br />
         <span class="text-indigo-300">On your own server.</span>
@@ -106,6 +132,11 @@ const repos = [
       <p class="mt-6 max-w-2xl text-lg text-slate-300 sm:text-xl">
         A self-hosted, privacy-focused tracker for physical books, manga, comics,
         and technical documents. One instance, many libraries, zero telemetry.
+      </p>
+      <p class="mt-4 max-w-2xl text-sm text-slate-400">
+        Heads up: Librarium is in early beta. Things are changing fast, some
+        edges are rough, and self-hosters should expect to read release notes
+        before upgrading.
       </p>
       <div class="mt-10 flex flex-wrap items-center gap-4">
         <a
@@ -125,17 +156,221 @@ const repos = [
   </header>
 
   <!-- Features -->
-  <section class="mx-auto max-w-6xl px-6 py-24">
+  <section class="bg-slate-900/30">
+    <div class="mx-auto max-w-6xl px-6 py-24">
     <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
       Built for collectors who run their own stack.
     </h2>
     <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
       {features.map((f) => (
         <div class="rounded-lg border border-slate-800 bg-slate-900/50 p-6">
+          <div class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-md bg-indigo-500/10 text-indigo-300">
+            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              {f.icon === 'server' && (
+                <>
+                  <rect x="3.5" y="3.5" width="17" height="7" rx="1.25" />
+                  <rect x="3.5" y="13" width="17" height="7" rx="1.25" />
+                  <circle cx="7" cy="7" r="0.6" fill="currentColor" />
+                  <circle cx="7" cy="16.5" r="0.6" fill="currentColor" />
+                  <path d="M10.5 7h6M10.5 16.5h6" />
+                </>
+              )}
+              {f.icon === 'users' && (
+                <>
+                  <circle cx="9" cy="8" r="3" />
+                  <path d="M3 19c0-3 2.7-5.5 6-5.5s6 2.5 6 5.5" />
+                  <circle cx="17" cy="9.5" r="2.2" />
+                  <path d="M15.5 17c.2-1.8 1.9-3 3.5-3s3 1.2 3 3" />
+                </>
+              )}
+              {f.icon === 'book' && (
+                <>
+                  <path d="M12 6.5c-2-1.5-4-2-7-2v13c3 0 5 .5 7 2" />
+                  <path d="M12 6.5c2-1.5 4-2 7-2v13c-3 0-5 .5-7 2" />
+                  <path d="M12 6.5V19.5" />
+                </>
+              )}
+              {f.icon === 'sparkles' && (
+                <>
+                  <path d="M12 3l1.4 4.2L17.6 8.5l-4.2 1.3L12 14l-1.4-4.2L6.4 8.5l4.2-1.3z" />
+                  <path d="M18.5 14.5l.7 2 2 .7-2 .7-.7 2-.7-2-2-.7 2-.7z" />
+                  <path d="M5 17.5l.5 1.5L7 19.5l-1.5.5L5 21.5l-.5-1.5L3 19.5l1.5-.5z" />
+                </>
+              )}
+              {f.icon === 'clock' && (
+                <>
+                  <circle cx="12" cy="12" r="8.5" />
+                  <path d="M12 7.5V12l3 2" />
+                </>
+              )}
+              {f.icon === 'folder' && (
+                <>
+                  <path d="M3.5 7a2 2 0 0 1 2-2h3.2a2 2 0 0 1 1.4.6l1.2 1.2a2 2 0 0 0 1.4.6h5.8a2 2 0 0 1 2 2v7.1a2 2 0 0 1-2 2H5.5a2 2 0 0 1-2-2z" />
+                </>
+              )}
+              {f.icon === 'devices' && (
+                <>
+                  <rect x="2.5" y="5" width="13" height="9" rx="1.25" />
+                  <path d="M2.5 16.5h13" />
+                  <path d="M7 18.5h4" />
+                  <rect x="16.5" y="8.5" width="5" height="11" rx="1.25" />
+                </>
+              )}
+              {f.icon === 'code' && (
+                <>
+                  <path d="M8.5 7L3.5 12l5 5" />
+                  <path d="M15.5 7l5 5-5 5" />
+                  <path d="M13.75 5L10.25 19" />
+                </>
+              )}
+            </svg>
+          </div>
           <h3 class="text-lg font-semibold text-white">{f.title}</h3>
           <p class="mt-2 text-sm leading-relaxed text-slate-300">{f.body}</p>
         </div>
       ))}
+    </div>
+    </div>
+  </section>
+
+  <!-- Comparison -->
+  <section id="compare" class="border-t border-slate-800">
+    <div class="mx-auto max-w-6xl px-6 py-24">
+      <p class="text-sm font-semibold tracking-widest text-indigo-300 uppercase">
+        Compared
+      </p>
+      <h2 class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        Pick the tool that fits your shelf.
+      </h2>
+      <p class="mt-3 max-w-2xl text-slate-300">
+        A quick sanity check for self-hosters weighing the options. An asterisk means
+        the item is on the Librarium roadmap, not shipped yet.
+      </p>
+      <div class="mt-10 overflow-x-auto rounded-lg border border-slate-800">
+        <table class="min-w-full divide-y divide-slate-800 text-sm">
+          <thead class="bg-slate-950/60">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left font-semibold text-slate-300">Feature</th>
+              <th scope="col" class="px-4 py-3 text-center font-semibold text-indigo-300">Librarium</th>
+              <th scope="col" class="px-4 py-3 text-center font-semibold text-slate-400">Calibre</th>
+              <th scope="col" class="px-4 py-3 text-center font-semibold text-slate-400">Readarr</th>
+              <th scope="col" class="px-4 py-3 text-center font-semibold text-slate-400">Bookwyrm</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-800 text-slate-300">
+            <tr>
+              <td class="px-4 py-3">Self-hosted</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Multi-user with per-library roles</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">Basic</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Print-first catalog (physical books, manga, comics)</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">Ebook-first</td>
+              <td class="px-4 py-3 text-center text-slate-500">Ebook-first</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Native iOS app with barcode scanning</td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-amber-400">◐</span>
+                <span class="block text-xs text-slate-500">TestFlight</span>
+              </td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">REST / OpenAPI</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">Limited</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">AI suggestions (Ollama / Osaurus / OpenAI / Anthropic)</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Scheduled-jobs dashboard</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Track books lent to friends and family</td>
+              <td class="px-4 py-3 text-center"><span class="text-amber-400">◐</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Goodreads / Libib / StoryGraph CSV import</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Shared reading feed / activity</td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-emerald-400">✓</span><span class="text-amber-400">*</span>
+                <span class="block text-xs text-slate-500">household only</span>
+              </td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-emerald-400">✓</span>
+                <span class="block text-xs text-slate-500">federated</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Automated ebook acquisition</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-3 text-center text-slate-500">No</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3">Open source</td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-emerald-400">✓</span>
+                <span class="block text-xs text-slate-500">Apache&nbsp;2.0</span>
+              </td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-emerald-400">✓</span>
+                <span class="block text-xs text-slate-500">GPL</span>
+              </td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-emerald-400">✓</span>
+                <span class="block text-xs text-slate-500">GPL</span>
+              </td>
+              <td class="px-4 py-3 text-center">
+                <span class="text-emerald-400">✓</span>
+                <span class="block text-xs text-slate-500">AGPL</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="mt-4 text-xs text-slate-500">
+        <span class="text-amber-400">◐</span> Partially shipped.
+        <span class="ml-3 text-amber-400">*</span> Planned roadmap item, not shipped yet.
+        Comparisons reflect each project's upstream as of 26.4.
+      </p>
     </div>
   </section>
 
@@ -148,10 +383,10 @@ const repos = [
       <h2 class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
         Browse, search, and curate from any browser.
       </h2>
-      <div class="relative mt-12" data-web-carousel-root>
+      <div class="relative mt-12" data-carousel-root>
         <div
           class="flex snap-x snap-mandatory overflow-x-auto scroll-smooth rounded-lg [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          data-web-carousel
+          data-carousel-track
         >
           {webShots.map((shot) => (
             <figure class="w-full flex-shrink-0 snap-center overflow-hidden rounded-lg border border-slate-800 bg-slate-950 shadow-xl">
@@ -167,7 +402,7 @@ const repos = [
 
         <button
           type="button"
-          data-web-prev
+          data-carousel-prev
           aria-label="Previous screenshot"
           class="absolute top-1/2 left-2 -translate-y-1/2 rounded-full border border-slate-700 bg-slate-950/80 p-2 text-white backdrop-blur transition hover:bg-slate-800 sm:left-4"
         >
@@ -177,7 +412,7 @@ const repos = [
         </button>
         <button
           type="button"
-          data-web-next
+          data-carousel-next
           aria-label="Next screenshot"
           class="absolute top-1/2 right-2 -translate-y-1/2 rounded-full border border-slate-700 bg-slate-950/80 p-2 text-white backdrop-blur transition hover:bg-slate-800 sm:right-4"
         >
@@ -186,7 +421,7 @@ const repos = [
           </svg>
         </button>
 
-        <div class="mt-6 flex justify-center gap-2" data-web-dots>
+        <div class="mt-6 flex justify-center gap-2" data-carousel-dots>
           {webShots.map((_, i) => (
             <button
               type="button"
@@ -197,87 +432,6 @@ const repos = [
           ))}
         </div>
       </div>
-
-      <script>
-        const root = document.querySelector<HTMLElement>('[data-web-carousel-root]');
-        if (root) {
-          const carousel = root.querySelector<HTMLElement>('[data-web-carousel]')!;
-          const slides = Array.from(carousel.children) as HTMLElement[];
-          const dots = Array.from(
-            root.querySelectorAll<HTMLElement>('[data-web-dots] button')
-          );
-          const prev = root.querySelector<HTMLButtonElement>('[data-web-prev]')!;
-          const next = root.querySelector<HTMLButtonElement>('[data-web-next]')!;
-          const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-          const INTERVAL = 5000;
-          let current = 0;
-          let timer: number | undefined;
-
-          const paintDots = () => {
-            dots.forEach((d, n) => {
-              if (n === current) d.dataset.active = '';
-              else delete d.dataset.active;
-            });
-          };
-
-          const goTo = (i: number) => {
-            current = (i + slides.length) % slides.length;
-            carousel.scrollTo({
-              left: current * carousel.clientWidth,
-              behavior: 'smooth',
-            });
-            paintDots();
-          };
-
-          const stop = () => {
-            if (timer) {
-              clearInterval(timer);
-              timer = undefined;
-            }
-          };
-          const start = () => {
-            if (reduced) return;
-            stop();
-            timer = window.setInterval(() => goTo(current + 1), INTERVAL);
-          };
-
-          prev.addEventListener('click', () => {
-            goTo(current - 1);
-            start();
-          });
-          next.addEventListener('click', () => {
-            goTo(current + 1);
-            start();
-          });
-          dots.forEach((d, i) =>
-            d.addEventListener('click', () => {
-              goTo(i);
-              start();
-            })
-          );
-
-          let scrollSync: number | undefined;
-          carousel.addEventListener('scroll', () => {
-            if (scrollSync) clearTimeout(scrollSync);
-            scrollSync = window.setTimeout(() => {
-              const i = Math.round(carousel.scrollLeft / carousel.clientWidth);
-              if (i !== current) {
-                current = i;
-                paintDots();
-                start();
-              }
-            }, 120);
-          });
-
-          root.addEventListener('mouseenter', stop);
-          root.addEventListener('mouseleave', start);
-          root.addEventListener('focusin', stop);
-          root.addEventListener('focusout', start);
-
-          paintDots();
-          start();
-        }
-      </script>
     </div>
   </section>
 
@@ -288,25 +442,155 @@ const repos = [
         iOS
       </p>
       <h2 class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-        Scan barcodes at the bookstore. Catch up at home.
+        Scan at the bookstore. One tap to see if you already own it, or add it to any library if you don't.
       </h2>
-      <div class="mt-12 flex flex-wrap justify-center gap-8">
-        {iosShots.map((shot) => (
-          <figure class="w-full max-w-xs overflow-hidden rounded-[2rem] border border-slate-800 bg-slate-950 shadow-2xl">
-            <img
-              src={shot.src}
-              alt={shot.alt}
-              loading="lazy"
-              class="h-auto w-full"
-            />
-          </figure>
-        ))}
+      <div class="relative mt-12" data-carousel-root>
+        <div
+          class="flex snap-x snap-mandatory overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          data-carousel-track
+        >
+          {iosShots.map((shot) => (
+            <div class="flex w-full flex-shrink-0 snap-center justify-center px-4 py-2">
+              <figure class="w-full max-w-xs overflow-hidden rounded-[2rem] border border-slate-800 bg-slate-950 shadow-2xl">
+                <img
+                  src={shot.src}
+                  alt={shot.alt}
+                  loading="lazy"
+                  class="h-auto w-full"
+                />
+              </figure>
+            </div>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          data-carousel-prev
+          aria-label="Previous screenshot"
+          class="absolute top-1/2 left-2 -translate-y-1/2 rounded-full border border-slate-700 bg-slate-950/80 p-2 text-white backdrop-blur transition hover:bg-slate-800 sm:left-4"
+        >
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          data-carousel-next
+          aria-label="Next screenshot"
+          class="absolute top-1/2 right-2 -translate-y-1/2 rounded-full border border-slate-700 bg-slate-950/80 p-2 text-white backdrop-blur transition hover:bg-slate-800 sm:right-4"
+        >
+          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+          </svg>
+        </button>
+
+        <div class="mt-6 flex justify-center gap-2" data-carousel-dots>
+          {iosShots.map((_, i) => (
+            <button
+              type="button"
+              data-index={i}
+              aria-label={`Go to screenshot ${i + 1}`}
+              class="h-2 w-2 rounded-full bg-slate-700 transition hover:bg-slate-500 data-[active]:w-6 data-[active]:bg-indigo-400"
+            ></button>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    // Shared carousel behaviour — picks up every `[data-carousel-root]`
+    // on the page and wires its track/prev/next/dots. Handles autoplay,
+    // hover/focus pause, scroll-sync, and reduced-motion.
+    for (const root of document.querySelectorAll<HTMLElement>('[data-carousel-root]')) {
+      const track = root.querySelector<HTMLElement>('[data-carousel-track]');
+      if (!track) continue;
+      const slides = Array.from(track.children) as HTMLElement[];
+      if (slides.length === 0) continue;
+      const dots = Array.from(
+        root.querySelectorAll<HTMLElement>('[data-carousel-dots] button')
+      );
+      const prev = root.querySelector<HTMLButtonElement>('[data-carousel-prev]');
+      const next = root.querySelector<HTMLButtonElement>('[data-carousel-next]');
+      const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const INTERVAL = 5000;
+      let current = 0;
+      let timer: number | undefined;
+
+      const paintDots = () => {
+        dots.forEach((d, n) => {
+          if (n === current) d.dataset.active = '';
+          else delete d.dataset.active;
+        });
+      };
+
+      const goTo = (i: number) => {
+        current = (i + slides.length) % slides.length;
+        track.scrollTo({ left: current * track.clientWidth, behavior: 'smooth' });
+        paintDots();
+      };
+
+      const stop = () => {
+        if (timer) { clearInterval(timer); timer = undefined; }
+      };
+      const start = () => {
+        if (reduced) return;
+        stop();
+        timer = window.setInterval(() => goTo(current + 1), INTERVAL);
+      };
+
+      prev?.addEventListener('click', () => { goTo(current - 1); start(); });
+      next?.addEventListener('click', () => { goTo(current + 1); start(); });
+      dots.forEach((d, i) => d.addEventListener('click', () => { goTo(i); start(); }));
+
+      let scrollSync: number | undefined;
+      track.addEventListener('scroll', () => {
+        if (scrollSync) clearTimeout(scrollSync);
+        scrollSync = window.setTimeout(() => {
+          const i = Math.round(track.scrollLeft / track.clientWidth);
+          if (i !== current) { current = i; paintDots(); start(); }
+        }, 120);
+      });
+
+      root.addEventListener('mouseenter', stop);
+      root.addEventListener('mouseleave', start);
+      root.addEventListener('focusin', stop);
+      root.addEventListener('focusout', start);
+
+      paintDots();
+      start();
+    }
+  </script>
+
+  <!-- Roadmap -->
+  <section id="roadmap" class="border-t border-slate-800 bg-slate-900/30">
+    <div class="mx-auto max-w-6xl px-6 py-24">
+      <p class="text-sm font-semibold tracking-widest text-indigo-300 uppercase">
+        Roadmap
+      </p>
+      <h2 class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        What's next.
+      </h2>
+      <p class="mt-3 max-w-2xl text-slate-300">
+        A proper public roadmap is on the way. Until then, watch the repos for
+        commits and releases.
+      </p>
+      <div class="mt-10">
+        <button
+          type="button"
+          disabled
+          aria-disabled="true"
+          class="inline-flex cursor-not-allowed items-center gap-2 rounded-md border border-slate-700 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-400"
+        >
+          <span class="h-1.5 w-1.5 rounded-full bg-amber-400"></span>
+          Coming soon
+        </button>
       </div>
     </div>
   </section>
 
   <!-- Repos -->
-  <section class="border-t border-slate-800 bg-slate-900/30">
+  <section class="border-t border-slate-800">
     <div class="mx-auto max-w-6xl px-6 py-24">
       <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
         Three repos, one product.
@@ -338,7 +622,7 @@ const repos = [
                 class="rounded-full bg-slate-800/80 px-2 py-0.5 font-mono text-slate-300 opacity-0 transition-opacity data-[loaded]:opacity-100"
                 data-version
                 aria-live="polite"
-              >—</span>
+              >·</span>
             </p>
           </a>
         ))}
@@ -350,7 +634,7 @@ const repos = [
     // Fetch the latest release tag for each repo card from the GitHub API.
     // Runs once on load. Unauthenticated requests are limited to 60/hr/IP,
     // which is plenty for a landing page. Repos without releases or with
-    // API errors stay at the "—" placeholder and hide the badge.
+    // API errors stay at the "·" placeholder and hide the badge.
     const cards = document.querySelectorAll<HTMLElement>('[data-repo]');
     for (const card of cards) {
       const repo = card.dataset.repo;


### PR DESCRIPTION
- Adds an Early-beta pill, refreshes the features grid with icons + cards for AI suggestions and scheduled jobs, converts iOS screenshots to a carousel, and drops a 12-row comparison table vs Calibre / Readarr / Bookwyrm with ✓* for planned items and ◐ for partially shipped.
- New Roadmap anchor + top-nav links for Compare / Roadmap. Background cadence strict-alternates after the hero.