### PR TITLE
feat(site): add librarium-mcp as a companion service

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ API-first: every client consumes the same OpenAPI contract, and each piece ships
 | [librarium-web](https://github.com/fireball1725/librarium-web) | React · TypeScript · Tailwind · Vite |
 | [librarium-ios](https://github.com/fireball1725/librarium-ios) | SwiftUI · iOS 26+ (TestFlight)       |
 
+Plus an optional companion service for AI clients:
+
+| Repo                                                           | Stack                                |
+| -------------------------------------------------------------- | ------------------------------------ |
+| [librarium-mcp](https://github.com/fireball1725/librarium-mcp) | MCP server · Go · streamable HTTP    |
+
 
 ## Get started
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,6 +64,10 @@ const repos = [
   { name: 'librarium-web', desc: 'React + TypeScript + Tailwind + Vite', href: 'https://github.com/fireball1725/librarium-web' },
   { name: 'librarium-ios', desc: 'SwiftUI · iOS 26+', href: 'https://github.com/fireball1725/librarium-ios' },
 ];
+
+const companions = [
+  { name: 'librarium-mcp', desc: 'MCP server · Go · streamable HTTP', href: 'https://github.com/fireball1725/librarium-mcp' },
+];
 ---
 
 <Layout>
@@ -683,6 +687,46 @@ const repos = [
             </p>
           </a>
         ))}
+      </div>
+
+      <div class="mt-16 border-t border-slate-800 pt-12">
+        <h3 class="text-2xl font-bold tracking-tight text-white sm:text-3xl">
+          Plus: chat with your library.
+        </h3>
+        <p class="mt-3 max-w-2xl text-slate-300">
+          Optional companion service. Speak MCP to Claude Desktop, Cursor, Claude Code,
+          or any MCP-aware client and let it search, read, add, and rate books on your
+          behalf. Runs alongside your existing stack, authenticates with a regular API
+          token, writes are gated by per-call approval in the client.
+        </p>
+        <div class="mt-8 grid gap-6 sm:grid-cols-3">
+          {companions.map((r) => (
+            <a
+              href={r.href}
+              class="group rounded-lg border border-slate-800 bg-slate-950 p-6 transition hover:border-indigo-500"
+              data-repo={r.name}
+            >
+              <div class="flex items-center justify-between">
+                <span class="font-mono text-sm text-white">{r.name}</span>
+                <span
+                  class="text-slate-500 transition group-hover:translate-x-1 group-hover:text-indigo-300"
+                  aria-hidden="true"
+                >
+                  →
+                </span>
+              </div>
+              <p class="mt-2 text-sm text-slate-400">{r.desc}</p>
+              <p class="mt-4 flex items-center gap-2 text-xs">
+                <span class="font-mono text-slate-500">latest</span>
+                <span
+                  class="rounded-full bg-slate-800/80 px-2 py-0.5 font-mono text-slate-300 opacity-0 transition-opacity data-[loaded]:opacity-100"
+                  data-version
+                  aria-live="polite"
+                >·</span>
+              </p>
+            </a>
+          ))}
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
- 'Three repos, one product.' keeps its trio; a new 'Plus: chat with your library.' subsection below it introduces librarium-mcp without putting it on the same tier as api/web/ios.
- README mirrors the same split: main three-repo table unchanged, MCP listed separately under it.