### PR TITLE
feat(site): cloud trackers comparison + FAQPage schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Self-hosted, privacy-focused library tracker for physical books, manga, comics, 
 - **Scheduled work, observable.** Cover backfills, metadata refreshes, and AI runs all live on a single cron-driven jobs page. Run on demand, inspect history, or let it tick quietly.
 - **Bring your own storage.** For ebooks and PDFs, Librarium stores a path reference. Your files stay where you put them.
 - **Cross-platform.** Go API, React web UI, and a native SwiftUI iOS app (TestFlight today, App Store soon).
-- **Open source.** Apache 2.0. Ship patches, file issues, or fork it.
+- **Open source.** AGPL 3.0. Ship patches, file issues, or fork it.
 
 ## Where the code lives
 
@@ -57,4 +57,4 @@ npm run build    # static build to dist/
 
 ## License
 
-Apache 2.0, matching the component repos.
+AGPL 3.0, matching the component repos.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,6 +68,37 @@ const repos = [
 const companions = [
   { name: 'librarium-mcp', desc: 'MCP server · Go · streamable HTTP', href: 'https://github.com/fireball1725/librarium-mcp' },
 ];
+
+// Frequently-asked questions surfaced both in the visible HTML below and
+// as FAQPage JSON-LD. The visible answer text and the schema answer text
+// must match — Google's policy is that FAQ schema only marks up content
+// that is genuinely on the page. Edit one, edit the other.
+const faqs = [
+  {
+    q: 'Is Librarium a self-hosted alternative to Goodreads?',
+    a: 'Yes. Librarium runs on your own hardware (Docker or Kubernetes), keeps your reading data on your server, and has no ads, no parent-company tracking, and no vendor lock-in. The closest fit if you want a Goodreads or StoryGraph experience without sending everything to a cloud service.',
+  },
+  {
+    q: 'How is Librarium different from Calibre or Readarr?',
+    a: 'Calibre and Readarr are ebook-first — they exist to manage downloaded files. Librarium is print-first: it catalogs the physical book, manga, comic, or magazine on your shelf using a work/edition data model (FRBR-style), and treats ebook or audiobook files as optional references hanging off an edition. If your shelves are mostly physical, Librarium fits the way you already think about a collection.',
+  },
+  {
+    q: 'Does Librarium have a mobile app?',
+    a: 'Yes — a native SwiftUI iOS app, currently in TestFlight with the App Store release coming next. The iOS app includes barcode scanning so you can add books straight from a bookstore shelf. There is no Android client today, and no committed plan to build one.',
+  },
+  {
+    q: 'Is Librarium free?',
+    a: 'Yes. Every repo is AGPL 3.0 licensed. You self-host, you own it. There is no paid tier and no managed cloud version — the project is intentionally self-hosted only.',
+  },
+  {
+    q: 'Does Librarium send my data anywhere?',
+    a: 'No telemetry. The only outbound network calls are metadata lookups you actively trigger — ISBN scans, cover backfills — and you choose which providers to enable. Optional AI reading suggestions are off by default and use either your local Ollama instance or your own OpenAI / Anthropic API keys.',
+  },
+  {
+    q: 'Can I import my Goodreads, StoryGraph, or Libib library?',
+    a: 'CSV import from Goodreads, StoryGraph, and Libib is on the 26.5 roadmap. Once shipped, you drop in the export from any of those services and Librarium will hydrate the catalog with metadata and covers from your configured providers.',
+  },
+];
 ---
 
 <Layout>
@@ -89,6 +120,7 @@ const companions = [
       <div class="hidden items-center gap-6 text-sm md:flex">
         <a href="#compare" class="text-slate-300 transition hover:text-white">Compare</a>
         <a href="#screenshots" class="text-slate-300 transition hover:text-white">Screenshots</a>
+        <a href="#faq" class="text-slate-300 transition hover:text-white">FAQ</a>
         <a href="#roadmap" class="text-slate-300 transition hover:text-white">Roadmap</a>
         <a
           href="https://fireball1725.github.io/librarium-api/"
@@ -132,6 +164,7 @@ const companions = [
       <div class="mx-auto flex max-w-6xl flex-col gap-1 px-6 py-3 text-sm">
         <a href="#compare" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Compare</a>
         <a href="#screenshots" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Screenshots</a>
+        <a href="#faq" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">FAQ</a>
         <a href="#roadmap" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Roadmap</a>
         <a href="https://fireball1725.github.io/librarium-api/" rel="noopener" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">API docs</a>
         <a href="https://github.com/fireball1725/librarium" rel="noopener" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">GitHub</a>
@@ -655,6 +688,48 @@ const companions = [
         };
         tabs.forEach((t) => t.addEventListener('click', () => activate(t.dataset.compareTab ?? 'self-hosted')));
       </script>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <!--
+    Visible Q&A list whose content mirrors the FAQPage JSON-LD emitted at
+    the end of this section. Google's policy is that FAQ schema only
+    decorates content that's actually on the page; if we ever change
+    answers in the schema without updating the visible copy (or vice
+    versa), the page becomes ineligible for FAQ rich results — keep them
+    in sync via the shared `faqs` array above.
+  -->
+  <section id="faq" class="border-t border-slate-800">
+    <div class="mx-auto max-w-6xl px-6 py-24">
+      <p class="text-sm font-semibold tracking-widest text-indigo-300 uppercase">
+        FAQ
+      </p>
+      <h2 class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        Frequently asked questions.
+      </h2>
+
+      <dl class="mt-12 divide-y divide-slate-800 border-y border-slate-800">
+        {faqs.map((f) => (
+          <div class="grid gap-3 py-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:gap-12">
+            <dt class="text-lg font-semibold text-white">{f.q}</dt>
+            <dd class="text-base leading-relaxed text-slate-300">{f.a}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <script
+        type="application/ld+json"
+        set:html={JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: faqs.map((f) => ({
+            '@type': 'Question',
+            name: f.q,
+            acceptedAnswer: { '@type': 'Answer', text: f.a },
+          })),
+        })}
+      />
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const features = [
   {
     icon: 'code',
     title: 'Open source',
-    body: 'Apache 2.0. Ship patches, file issues, or fork it. Each client lives in its own repo and ships on its own cadence.',
+    body: 'AGPL 3.0. Ship patches, file issues, or fork it. Each client lives in its own repo and ships on its own cadence.',
   },
 ];
 
@@ -309,122 +309,156 @@ const companions = [
         Pick the tool that fits your shelf.
       </h2>
       <p class="mt-3 max-w-2xl text-slate-300">
-        A quick sanity check for self-hosters weighing the options. An asterisk means
+        A quick sanity check for readers weighing the options. An asterisk means
         the item is on the Librarium roadmap, not shipped yet.
       </p>
-      <div class="mt-10 overflow-x-auto rounded-lg border border-slate-800">
-        <table class="min-w-full divide-y divide-slate-800 text-sm">
+
+      <!-- Compare tabs -->
+      <div class="mt-8 inline-flex rounded-lg border border-slate-800 bg-slate-950 p-1" role="tablist" aria-label="Comparison category">
+        <button
+          type="button"
+          role="tab"
+          id="tab-self-hosted"
+          aria-controls="panel-self-hosted"
+          aria-selected="true"
+          data-compare-tab="self-hosted"
+          class="rounded-md px-4 py-2 text-sm font-medium transition aria-selected:bg-indigo-500/15 aria-selected:text-indigo-200 text-slate-400 hover:text-white"
+        >
+          vs self-hosted
+        </button>
+        <button
+          type="button"
+          role="tab"
+          id="tab-cloud"
+          aria-controls="panel-cloud"
+          aria-selected="false"
+          data-compare-tab="cloud"
+          class="rounded-md px-4 py-2 text-sm font-medium transition aria-selected:bg-indigo-500/15 aria-selected:text-indigo-200 text-slate-400 hover:text-white"
+        >
+          vs cloud trackers
+        </button>
+      </div>
+
+      <!-- Self-hosted panel -->
+      <div
+        id="panel-self-hosted"
+        role="tabpanel"
+        aria-labelledby="tab-self-hosted"
+        data-compare-panel="self-hosted"
+      >
+      <div class="mt-6 overflow-x-auto rounded-lg border border-slate-800">
+        <table class="min-w-full table-fixed divide-y divide-slate-800 text-sm">
           <thead class="bg-slate-950/60">
             <tr>
-              <th scope="col" class="sticky left-0 z-10 min-w-[180px] bg-slate-950/90 px-4 py-3 text-left font-semibold text-slate-300 backdrop-blur">Feature</th>
-              <th scope="col" class="px-4 py-3 text-center font-semibold text-indigo-300">Librarium</th>
-              <th scope="col" class="px-4 py-3 text-center font-semibold text-slate-400">Calibre</th>
-              <th scope="col" class="px-4 py-3 text-center font-semibold text-slate-400">Readarr</th>
-              <th scope="col" class="px-4 py-3 text-center font-semibold text-slate-400">Bookwyrm</th>
+              <th scope="col" class="sticky left-0 z-10 w-2/5 min-w-[220px] bg-slate-950/90 px-4 py-1.5 text-left font-semibold text-slate-300 backdrop-blur">Feature</th>
+              <th scope="col" class="px-4 py-1.5 text-center font-semibold text-indigo-300">Librarium</th>
+              <th scope="col" class="px-4 py-1.5 text-center font-semibold text-slate-400">Calibre</th>
+              <th scope="col" class="px-4 py-1.5 text-center font-semibold text-slate-400">Readarr</th>
+              <th scope="col" class="px-4 py-1.5 text-center font-semibold text-slate-400">Bookwyrm</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-slate-800 text-slate-300">
+          <tbody class="divide-y divide-slate-800 text-slate-300 [&>tr]:h-12">
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Self-hosted</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Self-hosted</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Multi-user with per-library roles</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">Basic</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Multi-user with per-library roles</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">Basic</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Print-first catalog (physical books, manga, comics)</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">Ebook-first</td>
-              <td class="px-4 py-3 text-center text-slate-500">Ebook-first</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Print-first catalog (physical books, manga, comics)</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">Ebook-first</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">Ebook-first</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Native iOS app with barcode scanning</td>
-              <td class="px-4 py-3 text-center">
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Native iOS app with barcode scanning</td>
+              <td class="px-4 py-1.5 text-center">
                 <span class="text-amber-400">◐</span>
                 <span class="block text-xs text-slate-500">TestFlight</span>
               </td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">REST / OpenAPI</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">Limited</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">REST / OpenAPI</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">Limited</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">AI suggestions (Ollama / Osaurus / OpenAI / Anthropic)</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">AI suggestions (Ollama / Osaurus / OpenAI / Anthropic)</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Scheduled-jobs dashboard</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Scheduled-jobs dashboard</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Track books lent to friends and family</td>
-              <td class="px-4 py-3 text-center"><span class="text-amber-400">◐</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Track books lent to friends and family</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-amber-400">◐</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Goodreads / Libib / StoryGraph CSV import</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Goodreads / Libib / StoryGraph CSV import</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Shared reading feed / activity</td>
-              <td class="px-4 py-3 text-center">
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Shared reading feed / activity</td>
+              <td class="px-4 py-1.5 text-center">
                 <span class="text-emerald-400">✓</span><span class="text-amber-400">*</span>
                 <span class="block text-xs text-slate-500">household only</span>
               </td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center">
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center">
                 <span class="text-emerald-400">✓</span>
                 <span class="block text-xs text-slate-500">federated</span>
               </td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Automated ebook acquisition</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
-              <td class="px-4 py-3 text-center"><span class="text-emerald-400">✓</span></td>
-              <td class="px-4 py-3 text-center text-slate-500">No</td>
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Automated ebook acquisition</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              <td class="px-4 py-1.5 text-center text-slate-500">No</td>
             </tr>
             <tr>
-              <td class="sticky left-0 bg-slate-950/90 px-4 py-3 backdrop-blur">Open source</td>
-              <td class="px-4 py-3 text-center">
+              <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Open source</td>
+              <td class="px-4 py-1.5 text-center">
                 <span class="text-emerald-400">✓</span>
-                <span class="block text-xs text-slate-500">Apache&nbsp;2.0</span>
+                <span class="block text-xs text-slate-500">AGPL&nbsp;3.0</span>
               </td>
-              <td class="px-4 py-3 text-center">
-                <span class="text-emerald-400">✓</span>
-                <span class="block text-xs text-slate-500">GPL</span>
-              </td>
-              <td class="px-4 py-3 text-center">
+              <td class="px-4 py-1.5 text-center">
                 <span class="text-emerald-400">✓</span>
                 <span class="block text-xs text-slate-500">GPL</span>
               </td>
-              <td class="px-4 py-3 text-center">
+              <td class="px-4 py-1.5 text-center">
+                <span class="text-emerald-400">✓</span>
+                <span class="block text-xs text-slate-500">GPL</span>
+              </td>
+              <td class="px-4 py-1.5 text-center">
                 <span class="text-emerald-400">✓</span>
                 <span class="block text-xs text-slate-500">AGPL</span>
               </td>
@@ -432,11 +466,195 @@ const companions = [
           </tbody>
         </table>
       </div>
+      </div>
+
+      <!-- Cloud panel -->
+      <div
+        id="panel-cloud"
+        role="tabpanel"
+        aria-labelledby="tab-cloud"
+        data-compare-panel="cloud"
+        hidden
+      >
+        <div class="mt-6 overflow-x-auto rounded-lg border border-slate-800">
+          <table class="min-w-full table-fixed divide-y divide-slate-800 text-sm">
+            <thead class="bg-slate-950/60">
+              <tr>
+                <th scope="col" class="sticky left-0 z-10 w-2/5 min-w-[220px] bg-slate-950/90 px-4 py-1.5 text-left font-semibold text-slate-300 backdrop-blur">Feature</th>
+                <th scope="col" class="px-4 py-1.5 text-center font-semibold text-indigo-300">Librarium</th>
+                <th scope="col" class="px-4 py-1.5 text-center font-semibold text-slate-400">Goodreads</th>
+                <th scope="col" class="px-4 py-1.5 text-center font-semibold text-slate-400">StoryGraph</th>
+                <th scope="col" class="px-4 py-1.5 text-center font-semibold text-slate-400">Libib</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800 text-slate-300 [&>tr]:h-12">
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Self-hosted — runs on your hardware</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Your data stays yours (no vendor lock-in)</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">
+                  Amazon
+                  <span class="block text-xs text-slate-600">owner since 2013</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-500">Export</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">Export</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Public API for integrations</td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">REST · OpenAPI</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-500">
+                  Retired
+                  <span class="block text-xs text-slate-600">killed 2020</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">No ads, no data mining</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">Ads</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Works offline / LAN-only</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Print-first catalog (books, manga, comics)</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">Books</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">Books</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Multi-user household with per-library roles</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">AI suggestions under your control</td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">your keys</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Native mobile apps today</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">
+                  No
+                  <span class="block text-xs text-slate-600">iOS only · TestFlight</span>
+                </td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Barcode scanning</td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-amber-400">◐</span>
+                  <span class="block text-xs text-slate-500">TestFlight</span>
+                </td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span></td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Social reading feed (friends, reviews)</td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span><span class="text-amber-400">*</span>
+                  <span class="block text-xs text-slate-500">household only</span>
+                </td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">global</span>
+                </td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">global</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Goodreads / StoryGraph / Libib CSV import</td>
+                <td class="px-4 py-1.5 text-center"><span class="text-emerald-400">✓</span><span class="text-amber-400">*</span></td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">from Goodreads</span>
+                </td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">from Goodreads</span>
+                </td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Open source</td>
+                <td class="px-4 py-1.5 text-center">
+                  <span class="text-emerald-400">✓</span>
+                  <span class="block text-xs text-slate-500">AGPL&nbsp;3.0</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+                <td class="px-4 py-1.5 text-center text-slate-500">No</td>
+              </tr>
+              <tr>
+                <td class="sticky left-0 bg-slate-950/90 px-4 py-1.5 backdrop-blur">Cost</td>
+                <td class="px-4 py-1.5 text-center text-slate-300">Free</td>
+                <td class="px-4 py-1.5 text-center text-slate-300">Free</td>
+                <td class="px-4 py-1.5 text-center text-slate-300">
+                  Free / $4.99
+                  <span class="block text-xs text-slate-500">Plus tier</span>
+                </td>
+                <td class="px-4 py-1.5 text-center text-slate-300">
+                  Free / $9+
+                  <span class="block text-xs text-slate-500">paid tiers</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <p class="mt-4 text-xs text-slate-500">
         <span class="text-amber-400">◐</span> Partially shipped.
         <span class="ml-3 text-amber-400">*</span> Planned roadmap item, not shipped yet.
         Comparisons reflect each project's upstream as of 26.4.
       </p>
+
+      <script>
+        // Compare-section tab toggle. Static two-panel swap so no framework is
+        // needed; aria-selected drives the active-pill styling via Tailwind's
+        // aria-* variant, and the hidden attribute keeps the inactive panel out
+        // of the a11y tree entirely.
+        const tabs = document.querySelectorAll<HTMLButtonElement>('[data-compare-tab]');
+        const panels = document.querySelectorAll<HTMLElement>('[data-compare-panel]');
+        const activate = (which: string) => {
+          tabs.forEach((t) => t.setAttribute('aria-selected', String(t.dataset.compareTab === which)));
+          panels.forEach((p) => {
+            const match = p.dataset.comparePanel === which;
+            p.hidden = !match;
+          });
+        };
+        tabs.forEach((t) => t.addEventListener('click', () => activate(t.dataset.compareTab ?? 'self-hosted')));
+      </script>
     </div>
   </section>
 
@@ -764,7 +982,7 @@ const companions = [
       class="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-6 py-10 sm:flex-row sm:items-center"
     >
       <p class="text-sm text-slate-400">
-        © {new Date().getFullYear()} Librarium · Apache 2.0 licensed
+        © {new Date().getFullYear()} Librarium · AGPL 3.0 licensed
       </p>
       <div class="flex gap-6 text-sm text-slate-400">
         <a href="https://github.com/fireball1725/librarium" rel="noopener" class="hover:text-white">GitHub</a>


### PR DESCRIPTION
- Lands the long-pending tabbed comparison so the table now offers a "vs cloud trackers" view (Goodreads / StoryGraph / Libib) alongside the existing self-hosted matrix; same commit also fixes the lingering "Apache 2.0" → "AGPL 3.0" license string in the feature card and footer.
- Adds a visible "Frequently asked questions" section with six Q&A pairs and matching FAQPage JSON-LD so search engines and AI clients can surface "is this a Goodreads alternative?", "how does this compare to Calibre?", etc. as direct answers; visible copy and schema share one `faqs` array so they can't drift.