### PR TITLE
docs: link the README and site footer back to fireball1725.ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ npm run build    # static build to dist/
 ## License
 
 AGPL 3.0, matching the component repos.
+
+## Who builds this
+
+Created and maintained by [FireBall1725](https://fireball1725.ca) in Ontario, Canada. More projects and writing there, including [why Librarium exists](https://fireball1725.ca/blog/why-i-wrote-librarium).
+
+Patches welcome; see [CONTRIBUTING.md](./CONTRIBUTING.md). Everyone who has landed code is on the [contributors list](https://github.com/fireball1725/librarium/graphs/contributors).

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1221,7 +1221,12 @@ const roadmap = [
       class="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-6 py-10 sm:flex-row sm:items-center"
     >
       <p class="text-sm text-slate-400">
-        © {new Date().getFullYear()} Librarium · AGPL 3.0 licensed
+        © {new Date().getFullYear()} Librarium · AGPL 3.0 licensed · built by <a
+          href="https://fireball1725.ca"
+          rel="noopener"
+          class="text-slate-300 underline decoration-slate-700 underline-offset-4 hover:text-white hover:decoration-slate-400"
+          >FireBall1725</a
+        >
       </p>
       <div class="flex gap-6 text-sm text-slate-400">
         <a href="https://github.com/fireball1725/librarium" rel="noopener" class="hover:text-white">GitHub</a>


### PR DESCRIPTION
Adds the same "Who builds this" section the component repos now carry, plus a `built by FireBall1725` credit in the landing-page footer next to the copyright and licence line.

Points at the [contributors list](https://github.com/fireball1725/librarium/graphs/contributors) rather than naming people. Site builds clean and the link is in `dist/index.html`. All links verified 200.

Note: merging this deploys to librarium.press.