### PR TITLE
Drop the paid Plus tier, add the Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-hosted, privacy-focused tracker for your physical book, manga, and comic co
 
 > ⚠︎ **Early beta.** Things are changing fast, some edges are rough, and self-hosters should expect to read release notes before upgrading.
 
-[librarium.press](https://librarium.press) · [API docs](https://fireball1725.github.io/librarium-api/)
+[librarium.press](https://librarium.press) · [API docs](https://fireball1725.github.io/librarium-api/) · [Discord](https://discord.gg/QpV82CFfVD)
 
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,7 +93,7 @@ const faqs = [
   },
   {
     q: 'Is Librarium free?',
-    a: 'Self-hosted Librarium is free and AGPL 3.0 licensed, and it ships today. Lite for iOS will also be free. Plus, the hosted version we run for you, will be a paid monthly subscription with a free trial. Both Lite and Plus are on the roadmap.',
+    a: 'Yes. Self-hosted Librarium is free and AGPL 3.0 licensed, and it ships today. Lite for iOS will also be free, and it is next up. There is no paid tier, and nothing is held back for one. You run it, you own the data. If you would rather not run a server yourself, a cloud host like Railway will run the same containers for a few dollars a month; that is between you and them, not us.',
   },
   {
     q: 'Does Librarium send my data anywhere?',
@@ -125,7 +125,7 @@ const roadmap = [
       'CSV import (Goodreads, StoryGraph, Libib)',
       'Bookstore links',
       'Opt-in telemetry SDK',
-      'Plus hosted edition',
+      'One-click cloud deploy templates',
       'Series rework',
     ],
   },
@@ -394,13 +394,14 @@ const roadmap = [
         Editions
       </p>
       <h2 class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-        Three ways to run Librarium.
+        Two ways to run Librarium.
       </h2>
       <p class="mt-3 max-w-2xl text-slate-300">
-        Pick the one that fits how you want to manage your library. Self-hosted is shipping today; Lite and Plus are on the roadmap.
+        Both are free. Self-hosted ships today; Lite for iOS is next. Don't want to run a server? A cloud host will
+        run the same containers for a few dollars a month, and deploy templates to make that a shorter job are on the way.
       </p>
 
-      <div class="mt-12 grid gap-6 lg:grid-cols-3">
+      <div class="mt-12 grid gap-6 lg:grid-cols-2">
         <!-- Lite -->
         <div class="flex flex-col rounded-lg border border-slate-800 bg-slate-900/50 p-6">
           <div class="flex items-start justify-between gap-3">
@@ -418,7 +419,7 @@ const roadmap = [
             <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Works offline, syncs when online</li>
             <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Same data model as the server</li>
             <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>ISBN lookup via Open Library</li>
-            <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Promote to self-hosted or Plus any time</li>
+            <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Point it at your own server any time</li>
           </ul>
           <a
             href="https://testflight.apple.com/join/dA3sMnqR"
@@ -455,35 +456,6 @@ const roadmap = [
           >
             Deploy it
           </a>
-        </div>
-
-        <!-- Plus -->
-        <div class="flex flex-col rounded-lg border border-slate-800 bg-slate-900/50 p-6">
-          <div class="flex items-start justify-between gap-3">
-            <h3 class="text-xl font-semibold text-white">Plus</h3>
-            <span class="inline-flex items-center gap-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-0.5 text-xs font-semibold tracking-wide text-amber-300 uppercase">
-              <span class="h-1.5 w-1.5 rounded-full bg-amber-400"></span>
-              Coming soon
-            </span>
-          </div>
-          <p class="mt-2 text-2xl font-bold text-slate-300">Paid, free trial</p>
-          <p class="mt-4 text-sm text-slate-300">
-            We host Librarium for you. Free trial on launch. Walk away with your data whenever you want.
-          </p>
-          <ul class="mt-6 flex-1 space-y-2 text-sm text-slate-300">
-            <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Same feature set as self-hosted</li>
-            <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>We handle backups and updates</li>
-            <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Opt-in telemetry, off by default</li>
-            <li class="flex items-start gap-2"><span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-500"></span>Move to self-hosted any time</li>
-          </ul>
-          <button
-            type="button"
-            disabled
-            aria-disabled="true"
-            class="mt-8 inline-flex cursor-not-allowed items-center justify-center gap-2 rounded-md border border-slate-700 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-400"
-          >
-            On the roadmap
-          </button>
         </div>
       </div>
     </div>
@@ -1231,6 +1203,7 @@ const roadmap = [
       <div class="flex gap-6 text-sm text-slate-400">
         <a href="https://github.com/fireball1725/librarium" rel="noopener" class="hover:text-white">GitHub</a>
         <a href="https://github.com/fireball1725/librarium/issues" rel="noopener" class="hover:text-white">Issues</a>
+        <a href="https://discord.gg/QpV82CFfVD" rel="noopener" class="hover:text-white">Discord</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Plus was cancelled: running a hosted service means being on call for other people's servers. The site was still selling it, which made the homepage a promise nobody was going to keep.

- Removes the Plus pricing card, the tiers heading and intro, the FAQ answer, and the Plus item on the On deck list, which becomes one-click cloud deploy. Grid drops to two columns.
- Adds the FireBall Codes Discord to the footer beside GitHub and Issues.

**Left alone deliberately.** The `Plus tier` and `paid tiers` cells in the comparison table are StoryGraph's and Libib's own pricing, and `Plus: chat with your library` further down is the adverb. Both look like ours to a grep; editing the first would have put false pricing for a competitor on the site.

Verified in the browser: two balanced cards, no empty third column.