### PR TITLE
Add a public roadmap page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # The roadmap page fetches the latest release of each component repo at
+  # build time. Those repos ship on their own cadence and can't trigger a
+  # build here (GITHUB_TOKEN is scoped to its own repo, so cross-repo
+  # dispatch would need a PAT in four places). A nightly rebuild keeps the
+  # "Recently shipped" strip current within a day, with nothing to rotate.
+  schedule:
+    - cron: '17 6 * * *'
 
 permissions:
   contents: read
@@ -29,6 +36,12 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          # Lets the roadmap page's build-time release lookups use the
+          # authenticated rate limit. Unauthenticated is 60/hr per IP and
+          # Actions runners share addresses. The build tolerates a failure
+          # here: the shipped strip just disappears.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,23 @@
+---
+// Shared footer. Lifted out of index.astro when /roadmap was added.
+---
+
+<footer class="border-t border-slate-800">
+  <div
+    class="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-6 py-10 sm:flex-row sm:items-center"
+  >
+    <p class="text-sm text-slate-400">
+      © {new Date().getFullYear()} Librarium · AGPL 3.0 licensed · built by <a
+        href="https://fireball1725.ca"
+        rel="noopener"
+        class="text-slate-300 underline decoration-slate-700 underline-offset-4 hover:text-white hover:decoration-slate-400"
+        >FireBall1725</a
+      >
+    </p>
+    <div class="flex gap-6 text-sm text-slate-400">
+      <a href="https://github.com/fireball1725/librarium" rel="noopener" class="hover:text-white">GitHub</a>
+      <a href="https://github.com/fireball1725/librarium/issues" rel="noopener" class="hover:text-white">Issues</a>
+      <a href="https://discord.gg/QpV82CFfVD" rel="noopener" class="hover:text-white">Discord</a>
+    </div>
+  </div>
+</footer>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -1,0 +1,102 @@
+---
+// Shared top nav. Lifted out of index.astro when /roadmap was added, so the
+// two pages cannot drift apart.
+//
+// Section links are root-relative (`/#faq`, not `#faq`) so they work from any
+// page. On the homepage the browser treats them as a same-document jump; from
+// /roadmap they navigate home and then scroll.
+const base = import.meta.env.BASE_URL;
+const asset = (path: string) => `${base.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+const home = base.replace(/\/$/, '') || '/';
+
+const links = [
+  { href: `${home}/#editions`.replace('//#', '/#'), label: 'Editions' },
+  { href: `${home}/#compare`.replace('//#', '/#'), label: 'Compare' },
+  { href: `${home}/#screenshots`.replace('//#', '/#'), label: 'Screenshots' },
+  { href: `${home}/#faq`.replace('//#', '/#'), label: 'FAQ' },
+  { href: `${home}/roadmap`.replace(/\/\/roadmap$/, '/roadmap'), label: 'Roadmap' },
+  { href: 'https://fireball1725.github.io/librarium-api/', label: 'API docs', external: true },
+  { href: 'https://github.com/fireball1725/librarium', label: 'GitHub', external: true },
+];
+---
+
+<nav class="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+  <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+    <a href={base} class="flex items-center gap-2.5">
+      <img src={asset('logo-192.png')} alt="" width="32" height="32" class="h-8 w-8" />
+      <span class="text-lg font-semibold tracking-tight text-white">Librarium</span>
+    </a>
+
+    <!-- Desktop links -->
+    <div class="hidden items-center gap-6 text-sm md:flex">
+      {links.map((l) => (
+        <a
+          href={l.href}
+          rel={l.external ? 'noopener' : undefined}
+          class="text-slate-300 transition hover:text-white"
+        >
+          {l.label}
+        </a>
+      ))}
+    </div>
+
+    <!-- Mobile hamburger -->
+    <button
+      type="button"
+      data-mobile-nav-toggle
+      aria-label="Open menu"
+      aria-expanded="false"
+      aria-controls="mobile-nav"
+      class="inline-flex h-10 w-10 items-center justify-center rounded-md border border-slate-800 text-slate-300 transition hover:border-slate-600 hover:text-white md:hidden"
+    >
+      <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" data-menu-icon>
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+        <line x1="3" y1="18" x2="21" y2="18" />
+      </svg>
+      <svg class="hidden h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" data-close-icon>
+        <line x1="6" y1="6" x2="18" y2="18" />
+        <line x1="18" y1="6" x2="6" y2="18" />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Mobile menu panel -->
+  <div id="mobile-nav" class="hidden border-t border-slate-800 bg-slate-950/95 backdrop-blur md:hidden" data-mobile-nav>
+    <div class="mx-auto flex max-w-6xl flex-col gap-1 px-6 py-3 text-sm">
+      {links.map((l) => (
+        <a
+          href={l.href}
+          rel={l.external ? 'noopener' : undefined}
+          class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white"
+        >
+          {l.label}
+        </a>
+      ))}
+    </div>
+  </div>
+
+  <script>
+    // Mobile nav toggle — hamburger swaps with an X, menu panel shows/hides.
+    // Tapping any link inside the panel auto-closes it so the anchor scroll
+    // lands on content, not on the still-open menu.
+    const toggle = document.querySelector<HTMLButtonElement>('[data-mobile-nav-toggle]');
+    const panel = document.querySelector<HTMLElement>('[data-mobile-nav]');
+    const openIcon = toggle?.querySelector<SVGElement>('[data-menu-icon]');
+    const closeIcon = toggle?.querySelector<SVGElement>('[data-close-icon]');
+    if (toggle && panel && openIcon && closeIcon) {
+      const setOpen = (open: boolean) => {
+        panel.classList.toggle('hidden', !open);
+        openIcon.classList.toggle('hidden', open);
+        closeIcon.classList.toggle('hidden', !open);
+        toggle.setAttribute('aria-expanded', String(open));
+      };
+      toggle.addEventListener('click', () => {
+        setOpen(panel.classList.contains('hidden'));
+      });
+      panel.querySelectorAll('a').forEach(a =>
+        a.addEventListener('click', () => setOpen(false))
+      );
+    }
+  </script>
+</nav>

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -1,0 +1,192 @@
+// Public roadmap. Single source of truth for two renderings:
+//
+//   - the condensed three-column section on the homepage (#roadmap)
+//   - the full /roadmap page, which also shows blurbs, areas and the
+//     not-planning list
+//
+// Keep it that way. A second hand-maintained list is how the two drift.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// SECURITY REDACTION RULE — read before adding anything
+//
+// Security work appears here only once the mitigation has SHIPPED, described
+// as a shipped improvement. Never describe an unmitigated weakness, however
+// vaguely. A roadmap entry saying "harden X" tells an attacker that X is soft
+// in every deployed instance today, and self-hosters cannot patch on your
+// schedule.
+//
+// If an item cannot be described without disclosing a live gap, it belongs in
+// the private PLAN.md only. There is at least one such item there now.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type Status = 'shipping-next' | 'on-deck' | 'exploring' | 'not-planning';
+
+export type Area = 'api' | 'web' | 'ios' | 'mcp' | 'product';
+
+export interface RoadmapItem {
+  /** Short label. This is all the homepage shows, so it has to stand alone. */
+  title: string;
+  /** One or two sentences, user-facing. Shown on /roadmap only. */
+  blurb?: string;
+  status: Status;
+  areas: Area[];
+}
+
+export const STATUS_LABELS: Record<Status, string> = {
+  'shipping-next': 'Shipping next',
+  'on-deck': 'On deck',
+  exploring: 'Exploring',
+  'not-planning': 'Not planning',
+};
+
+/** Homepage shows these three, in this order. /roadmap adds not-planning. */
+export const HOMEPAGE_STATUSES: Status[] = ['shipping-next', 'on-deck', 'exploring'];
+
+export const roadmap: RoadmapItem[] = [
+  // ── Shipping next ──────────────────────────────────────────────────────
+  {
+    title: 'Lite mode for iOS',
+    blurb:
+      'A free iOS edition that keeps everything on device with iCloud sync across your Apple devices, no server to run. Point it at your own Librarium later if you want to.',
+    status: 'shipping-next',
+    areas: ['ios', 'api'],
+  },
+  {
+    title: 'iOS app redesign',
+    status: 'shipping-next',
+    areas: ['ios'],
+  },
+  {
+    title: 'Sync protocol (per-field timestamps, delta API)',
+    blurb:
+      'Field-level last-writer-wins with per-field timestamps, incremental deltas and tombstones. Underpins Lite, and fixes the flaky read-only offline cache for self-hosted users as a side effect.',
+    status: 'shipping-next',
+    areas: ['api', 'ios'],
+  },
+  {
+    title: 'App Store launch',
+    status: 'shipping-next',
+    areas: ['ios'],
+  },
+
+  // ── On deck ────────────────────────────────────────────────────────────
+  {
+    title: 'CSV import (Goodreads, StoryGraph, Libib)',
+    blurb:
+      'Drop in an export from any of them and Librarium hydrates the catalogue with metadata and covers from whichever providers you have enabled.',
+    status: 'on-deck',
+    areas: ['api', 'web'],
+  },
+  {
+    title: 'One-click cloud deploy templates',
+    blurb:
+      'Deploy templates so you can stand up your own instance on a cloud host without hand-rolling Compose. Railway first, then others. Your instance, your data, your bill.',
+    status: 'on-deck',
+    areas: ['api', 'web'],
+  },
+  {
+    title: 'Bookstore links',
+    status: 'on-deck',
+    areas: ['web', 'ios'],
+  },
+  {
+    title: 'Opt-in telemetry SDK',
+    blurb:
+      'Off by default, and gated twice on self-hosted: an operator flag plus per-user consent. The code that sends lives in the public repos.',
+    status: 'on-deck',
+    areas: ['api', 'web', 'ios'],
+  },
+  {
+    title: 'Series rework',
+    status: 'on-deck',
+    areas: ['api', 'web'],
+  },
+  {
+    title: 'Move books between libraries, in bulk',
+    blurb: 'There is no path for this in the UI today.',
+    status: 'on-deck',
+    areas: ['api', 'web'],
+  },
+  {
+    title: 'Higher-resolution covers',
+    blurb:
+      'Covers currently come back as a 128px thumbnail. Providers expose larger images; this makes that an option.',
+    status: 'on-deck',
+    areas: ['api', 'web'],
+  },
+
+  // ── Exploring ──────────────────────────────────────────────────────────
+  {
+    title: 'Pre-ISBN and vintage collections',
+    blurb:
+      'ISBN is already optional, but four things make older collections awkward: no way to describe what is inside an anthology or an Ace Double, publish dates that turn "1932" into 1 January 1932, no per-copy record for condition or provenance, and no identifiers beyond ISBN. The first is a real schema change; the rest are cheaper.',
+    status: 'exploring',
+    areas: ['api'],
+  },
+  {
+    title: 'Member reviews on book pages',
+    blurb:
+      'Reviews marked visible to members are stored but never shown to anyone else, so the field is half built. This would surface them on the book page, same-library scope only, with private notes staying private.',
+    status: 'exploring',
+    areas: ['api', 'web'],
+  },
+  {
+    title: 'One list of every book across libraries',
+    status: 'exploring',
+    areas: ['api', 'web'],
+  },
+  {
+    title: 'Edit metadata from the refresh panel',
+    status: 'exploring',
+    areas: ['web'],
+  },
+  {
+    title: 'Shared reading feed (household scope)',
+    status: 'exploring',
+    areas: ['api', 'web', 'ios'],
+  },
+  {
+    title: 'iPad and Mac apps',
+    status: 'exploring',
+    areas: ['ios'],
+  },
+  {
+    title: 'AI metadata enrichment',
+    status: 'exploring',
+    areas: ['api'],
+  },
+  {
+    title: 'Library invite links',
+    status: 'exploring',
+    areas: ['api', 'ios'],
+  },
+  {
+    title: 'Bulk select on books grid',
+    status: 'exploring',
+    areas: ['ios'],
+  },
+
+  // ── Not planning ───────────────────────────────────────────────────────
+  // Saying no costs nothing and saves people weeks. Worth as much as the rest.
+  {
+    title: 'A paid hosted edition',
+    blurb:
+      'Cancelled. Running a hosted service means being on call for other people’s servers. One-click deploy templates are the answer instead: your instance, your data. Nothing is held back from self-hosted for a commercial tier.',
+    status: 'not-planning',
+    areas: ['product'],
+  },
+  {
+    title: 'An Android app',
+    blurb:
+      "I don't have an Android device to test on, so there's nothing to develop against. The web UI works in a mobile browser in the meantime. This could change if I pick one up.",
+    status: 'not-planning',
+    areas: ['product'],
+  },
+  {
+    title: 'Federation between instances',
+    blurb:
+      'Running several of your own servers and switching between them is supported. A cross-instance social graph is a different product.',
+    status: 'not-planning',
+    areas: ['product'],
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,8 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SiteHeader from '../components/SiteHeader.astro';
+import SiteFooter from '../components/SiteFooter.astro';
+import { roadmap as roadmapItems, HOMEPAGE_STATUSES, STATUS_LABELS } from '../data/roadmap';
 
 const base = import.meta.env.BASE_URL;
 const asset = (path: string) => `${base.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
@@ -101,145 +104,28 @@ const faqs = [
   },
   {
     q: 'Can I import my Goodreads, StoryGraph, or Libib library?',
-    a: 'CSV import from Goodreads, StoryGraph, and Libib is on the 26.5 roadmap. Once shipped, you drop in the export from any of those services and Librarium will hydrate the catalog with metadata and covers from your configured providers.',
+    a: 'CSV import from Goodreads, StoryGraph, and Libib is on deck; see the roadmap. Once shipped, you drop in the export from any of those services and Librarium will hydrate the catalog with metadata and covers from your configured providers.',
   },
 ];
 
-const roadmap = [
-  {
-    status: 'Shipping next',
-    headerClass: 'text-emerald-300',
-    dotClass: 'bg-emerald-400',
-    items: [
-      'iOS app redesign',
-      'Lite mode for iOS',
-      'Sync protocol (per-field timestamps, delta API)',
-      'App Store launch',
-    ],
-  },
-  {
-    status: 'On deck',
-    headerClass: 'text-amber-300',
-    dotClass: 'bg-amber-400',
-    items: [
-      'CSV import (Goodreads, StoryGraph, Libib)',
-      'Bookstore links',
-      'Opt-in telemetry SDK',
-      'One-click cloud deploy templates',
-      'Series rework',
-    ],
-  },
-  {
-    status: 'Exploring',
-    headerClass: 'text-slate-400',
-    dotClass: 'bg-slate-500',
-    items: [
-      'iPad and Mac apps',
-      'Shared reading feed (household scope)',
-      'AI metadata enrichment',
-      'Library invite links',
-      'Bulk select on books grid',
-    ],
-  },
-];
+// Condensed view of src/data/roadmap.ts — titles only, three columns, and
+// not-planning left off. The full list with blurbs and issue links lives at
+// /roadmap. One data file, so the two can't drift.
+const columnStyles = {
+  'shipping-next': { headerClass: 'text-emerald-300', dotClass: 'bg-emerald-400' },
+  'on-deck': { headerClass: 'text-amber-300', dotClass: 'bg-amber-400' },
+  exploring: { headerClass: 'text-slate-400', dotClass: 'bg-slate-500' },
+} as const;
+
+const roadmap = HOMEPAGE_STATUSES.map((status) => ({
+  status: STATUS_LABELS[status],
+  ...columnStyles[status as keyof typeof columnStyles],
+  items: roadmapItems.filter((i) => i.status === status).map((i) => i.title),
+}));
 ---
 
 <Layout>
-  <!-- Top nav -->
-  <nav class="sticky top-0 z-20 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
-    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-      <a href={base} class="flex items-center gap-2.5">
-        <img
-          src={asset('logo-192.png')}
-          alt=""
-          width="32"
-          height="32"
-          class="h-8 w-8"
-        />
-        <span class="text-lg font-semibold tracking-tight text-white">Librarium</span>
-      </a>
-
-      <!-- Desktop links -->
-      <div class="hidden items-center gap-6 text-sm md:flex">
-        <a href="#editions" class="text-slate-300 transition hover:text-white">Editions</a>
-        <a href="#compare" class="text-slate-300 transition hover:text-white">Compare</a>
-        <a href="#screenshots" class="text-slate-300 transition hover:text-white">Screenshots</a>
-        <a href="#faq" class="text-slate-300 transition hover:text-white">FAQ</a>
-        <a href="#roadmap" class="text-slate-300 transition hover:text-white">Roadmap</a>
-        <a
-          href="https://fireball1725.github.io/librarium-api/"
-          rel="noopener"
-          class="text-slate-300 transition hover:text-white"
-        >
-          API docs
-        </a>
-        <a
-          href="https://github.com/fireball1725/librarium"
-          rel="noopener"
-          class="text-slate-300 transition hover:text-white"
-        >
-          GitHub
-        </a>
-      </div>
-
-      <!-- Mobile hamburger -->
-      <button
-        type="button"
-        data-mobile-nav-toggle
-        aria-label="Open menu"
-        aria-expanded="false"
-        aria-controls="mobile-nav"
-        class="inline-flex h-10 w-10 items-center justify-center rounded-md border border-slate-800 text-slate-300 transition hover:border-slate-600 hover:text-white md:hidden"
-      >
-        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" data-menu-icon>
-          <line x1="3" y1="6" x2="21" y2="6" />
-          <line x1="3" y1="12" x2="21" y2="12" />
-          <line x1="3" y1="18" x2="21" y2="18" />
-        </svg>
-        <svg class="hidden h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" data-close-icon>
-          <line x1="6" y1="6" x2="18" y2="18" />
-          <line x1="18" y1="6" x2="6" y2="18" />
-        </svg>
-      </button>
-    </div>
-
-    <!-- Mobile menu panel -->
-    <div id="mobile-nav" class="hidden border-t border-slate-800 bg-slate-950/95 backdrop-blur md:hidden" data-mobile-nav>
-      <div class="mx-auto flex max-w-6xl flex-col gap-1 px-6 py-3 text-sm">
-        <a href="#editions" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Editions</a>
-        <a href="#compare" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Compare</a>
-        <a href="#screenshots" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Screenshots</a>
-        <a href="#faq" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">FAQ</a>
-        <a href="#roadmap" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">Roadmap</a>
-        <a href="https://fireball1725.github.io/librarium-api/" rel="noopener" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">API docs</a>
-        <a href="https://github.com/fireball1725/librarium" rel="noopener" class="rounded px-2 py-2 text-slate-300 transition hover:bg-slate-900 hover:text-white">GitHub</a>
-      </div>
-    </div>
-
-    <script>
-      // Mobile nav toggle — hamburger swaps with an X, menu panel shows/hides.
-      // Tapping any link inside the panel auto-closes it so the anchor scroll
-      // lands on content, not on the still-open menu.
-      const toggle = document.querySelector<HTMLButtonElement>('[data-mobile-nav-toggle]');
-      const panel = document.querySelector<HTMLElement>('[data-mobile-nav]');
-      const openIcon = toggle?.querySelector<SVGElement>('[data-menu-icon]');
-      const closeIcon = toggle?.querySelector<SVGElement>('[data-close-icon]');
-      if (toggle && panel && openIcon && closeIcon) {
-        const setOpen = (open: boolean) => {
-          panel.classList.toggle('hidden', !open);
-          openIcon.classList.toggle('hidden', open);
-          closeIcon.classList.toggle('hidden', !open);
-          toggle.setAttribute('aria-expanded', String(open));
-        };
-        toggle.addEventListener('click', () => {
-          setOpen(panel.classList.contains('hidden'));
-        });
-        panel.querySelectorAll('a').forEach(a =>
-          a.addEventListener('click', () => setOpen(false))
-        );
-      }
-    </script>
-  </nav>
+  <SiteHeader />
 
   <!-- Hero -->
   <header class="relative overflow-hidden border-b border-slate-800">
@@ -1187,24 +1073,5 @@ const roadmap = [
     }
   </script>
 
-  <!-- Footer -->
-  <footer class="border-t border-slate-800">
-    <div
-      class="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-6 py-10 sm:flex-row sm:items-center"
-    >
-      <p class="text-sm text-slate-400">
-        © {new Date().getFullYear()} Librarium · AGPL 3.0 licensed · built by <a
-          href="https://fireball1725.ca"
-          rel="noopener"
-          class="text-slate-300 underline decoration-slate-700 underline-offset-4 hover:text-white hover:decoration-slate-400"
-          >FireBall1725</a
-        >
-      </p>
-      <div class="flex gap-6 text-sm text-slate-400">
-        <a href="https://github.com/fireball1725/librarium" rel="noopener" class="hover:text-white">GitHub</a>
-        <a href="https://github.com/fireball1725/librarium/issues" rel="noopener" class="hover:text-white">Issues</a>
-        <a href="https://discord.gg/QpV82CFfVD" rel="noopener" class="hover:text-white">Discord</a>
-      </div>
-    </div>
-  </footer>
+  <SiteFooter />
 </Layout>

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -1,0 +1,132 @@
+---
+import Layout from '../layouts/Layout.astro';
+import SiteHeader from '../components/SiteHeader.astro';
+import SiteFooter from '../components/SiteFooter.astro';
+import { roadmap, STATUS_LABELS, type Status } from '../data/roadmap';
+
+const ORDER: Status[] = ['shipping-next', 'on-deck', 'exploring', 'not-planning'];
+
+const STATUS_STYLES: Record<Status, { dot: string; text: string; blurb: string }> = {
+  'shipping-next': { dot: 'bg-emerald-400', text: 'text-emerald-300', blurb: 'Being built now.' },
+  'on-deck': { dot: 'bg-amber-400', text: 'text-amber-300', blurb: 'Queued up, not started.' },
+  exploring: { dot: 'bg-slate-500', text: 'text-slate-400', blurb: 'Wanted, no date, may change shape.' },
+  'not-planning': { dot: 'bg-slate-700', text: 'text-slate-500', blurb: "Asked about often enough to be worth answering. These aren't happening." },
+};
+
+const AREA_LABELS: Record<string, string> = {
+  api: 'api', web: 'web', ios: 'ios', mcp: 'mcp', product: 'product',
+};
+
+const groups = ORDER.map((status) => ({
+  status,
+  label: STATUS_LABELS[status],
+  ...STATUS_STYLES[status],
+  items: roadmap.filter((i) => i.status === status),
+})).filter((g) => g.items.length > 0);
+
+// ── Recently shipped ────────────────────────────────────────────────────
+// Fetched at BUILD time, not in the browser, so crawlers and no-JS visitors
+// see real versions. GITHUB_TOKEN is passed in by the deploy workflow:
+// unauthenticated calls are 60/hr per IP and Actions runners share addresses.
+//
+// A failure here must never break the build. The site going down because
+// GitHub had a bad minute would be a poor trade for a version string.
+const REPOS = ['librarium-api', 'librarium-web', 'librarium-ios', 'librarium-mcp'];
+const token = import.meta.env.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
+
+type Shipped = { repo: string; tag: string; url: string; date: string };
+
+const shipped: Shipped[] = (
+  await Promise.all(
+    REPOS.map(async (repo): Promise<Shipped | null> => {
+      try {
+        const res = await fetch(`https://api.github.com/repos/fireball1725/${repo}/releases/latest`, {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+        });
+        if (!res.ok) return null;
+        const d = await res.json();
+        if (!d?.tag_name) return null;
+        return { repo, tag: d.tag_name, url: d.html_url, date: d.published_at };
+      } catch {
+        return null;
+      }
+    })
+  )
+).filter((r): r is Shipped => r !== null)
+ .sort((a, b) => (a.date < b.date ? 1 : -1));
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-CA', { year: 'numeric', month: 'short', day: 'numeric' });
+---
+
+<Layout
+  title="Roadmap — Librarium"
+  description="What's being built in Librarium, what's queued, what's being explored, and what isn't happening."
+>
+  <SiteHeader />
+
+  <section class="border-b border-slate-800">
+    <div class="mx-auto max-w-6xl px-6 py-20">
+      <p class="text-sm font-semibold tracking-widest text-indigo-300 uppercase">Roadmap</p>
+      <h1 class="mt-2 text-4xl font-bold tracking-tight text-white sm:text-5xl">What's next.</h1>
+      <p class="mt-4 max-w-2xl text-slate-300">
+        Solo project, so these are intentions rather than promises, and things move between groups as
+        priorities shift. If something you want isn't
+        here, <a href="https://github.com/fireball1725/librarium/issues" rel="noopener" class="text-indigo-300 underline decoration-indigo-500/40 underline-offset-4 hover:text-indigo-200">open an issue</a>
+        or say so in <a href="https://discord.gg/QpV82CFfVD" rel="noopener" class="text-indigo-300 underline decoration-indigo-500/40 underline-offset-4 hover:text-indigo-200">Discord</a>.
+      </p>
+
+      {shipped.length > 0 && (
+        <div class="mt-10 rounded-lg border border-slate-800 bg-slate-900/40 p-5">
+          <p class="text-xs font-semibold tracking-widest text-slate-400 uppercase">Recently shipped</p>
+          <div class="mt-3 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            {shipped.map((r) => (
+              <a href={r.url} rel="noopener" class="group flex items-center gap-2">
+                <span class="font-mono text-slate-300 group-hover:text-white">{r.repo}</span>
+                <span class="rounded-full bg-slate-800/80 px-2 py-0.5 font-mono text-xs text-emerald-300">{r.tag}</span>
+                <span class="text-xs text-slate-500">{fmtDate(r.date)}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  </section>
+
+  <section>
+    <div class="mx-auto max-w-6xl space-y-16 px-6 py-20">
+      {groups.map((g) => (
+        <div>
+          <h2 class:list={['flex items-center gap-2 text-sm font-semibold tracking-widest uppercase', g.text]}>
+            <span class:list={['h-1.5 w-1.5 rounded-full', g.dot]}></span>
+            {g.label}
+          </h2>
+          <p class="mt-2 text-sm text-slate-500">{g.blurb}</p>
+
+          <ul class="mt-6 grid gap-4 sm:grid-cols-2">
+            {g.items.map((item) => (
+              <li class="rounded-lg border border-slate-800 bg-slate-900/40 p-5">
+                <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <h3 class="font-semibold text-white">{item.title}</h3>
+                  <span class="flex gap-1.5">
+                    {item.areas.map((a) => (
+                      <span class="rounded bg-slate-800/80 px-1.5 py-0.5 font-mono text-[11px] text-slate-400">
+                        {AREA_LABELS[a] ?? a}
+                      </span>
+                    ))}
+                  </span>
+                </div>
+                {item.blurb && <p class="mt-2 text-sm text-slate-300">{item.blurb}</p>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <SiteFooter />
+</Layout>


### PR DESCRIPTION
Adds a `/roadmap` page, rendered from a new `src/data/roadmap.ts`.

- The homepage roadmap section now renders from that same file, so the two can't drift.
- `/roadmap` shows the same items plus blurbs, repo tags, issue links, and a Not planning group.
- Recently shipped strip fetches each repo's latest release at build time. Nightly cron keeps it current.
- Nav and footer moved to `src/components/`; section links made root-relative so they work off the homepage.
- Fixes a stale "26.5 roadmap" reference in the FAQ.
