### PR TITLE
Run CI from the shared workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,68 @@
+; Shared across every FireBall1725 repo. Copied in by scaffold.sh; do not
+; hand-edit a copy. Change it here and re-run the script.
+;
+; Enforced in CI by editorconfig-checker, which is the reason this file is a
+; gate and not a suggestion. Language formatters (gofmt, swift-format, ruff)
+; own the files they know about; this covers everything they don't.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# gofmt writes tabs and is not configurable. indent_size here is display
+# width only; it does not change a single byte on disk.
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.{py,pyi}]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+# SQL indents continuation lines to align under keywords, so a WHERE clause
+# sits at 5 spaces and its AND at 7. That is alignment, not indentation, and
+# demanding multiples of two mangles it. Trailing whitespace and the final
+# newline are still checked.
+[*.sql]
+indent_size = unset
+
+# Helm templates indent to shape their rendered YAML, and their comment blocks
+# align continuation lines under prose. Neither lands on a multiple of two.
+[*.tpl]
+indent_size = unset
+
+# Two trailing spaces are a hard line break in Markdown, and indentation is
+# structural: content nested under "1. " is indented three spaces, which is
+# correct and is not a multiple of two. Leaving indent_size set here fails every
+# README that contains a fenced block inside a numbered list.
+[*.md]
+trim_trailing_whitespace = false
+indent_size = unset
+indent_style = unset
+
+# Files whose bytes belong to a tool, not to us. Xcode rewrites pbxproj on
+# every project change and will happily undo anything done here, and the XML in
+# these repos is vendored or generated data (glabels label catalogues, the
+# Sparkle appcast) rather than anything anyone formats by hand.
+[{*.pbxproj,*.xcscheme,*.plist,*.xml}]
+indent_style = unset
+indent_size = unset
+trim_trailing_whitespace = false
+insert_final_newline = unset
+
+# Whitespace is load-bearing in a diff.
+[*.{patch,diff}]
+trim_trailing_whitespace = false
+insert_final_newline = unset
+
+[LICENSE]
+indent_style = unset
+indent_size = unset

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Go is excluded because gofmt owns it and is gated separately in ci-go.yml. This checker cannot see inside a raw string literal, so it reads a space-indented HTML template in a handler, or fixtures in a _test.go, as wrong indentation: 60 such findings on firebin-api, every one inside a string.",
+  "Exclude": [
+    "\\.go$",
+    "^vendor/",
+    "^node_modules/",
+    "^\\.build/",
+    "^dist/",
+    "^docs/swagger\\.",
+    "^docs/docs\\.go$",
+    "Package\\.resolved$",
+    "package-lock\\.json$",
+    "\\.generated\\.swift$",
+    "\\.min\\.(js|css)$",
+    "\\.(png|jpg|jpeg|gif|ico|icns|pdf|woff2?|ttf|dmg|zip)$"
+  ],
+  "Verbose": false,
+  "IgnoreDefaults": false,
+  "SpacesAfterTabs": false,
+  "_comment_indentation": "Indentation is off because the rule is 'left padding must be a multiple of indent_size', which fires on ANY aligned continuation line rather than on genuinely wrong indentation. It flagged, in order: Go raw string literals, Markdown ordered-list nesting, SQL keyword alignment, a vendored glabels XML catalogue, a Helm comment block, CSS comment continuations, and a generated 4-space JSON manifest. Every one was formatted correctly. Indentation is enforced where it can be enforced honestly: gofmt for Go, eslint for TS, ruff for Python, swift-format for Swift. The .editorconfig still declares it, which is what editors read.",
+  "Disable": {
+    "EndOfLine": false,
+    "Indentation": true,
+    "InsertFinalNewline": false,
+    "TrimTrailingWhitespace": false,
+    "MaxLineLength": true
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,17 @@
-# PR-time validation for the marketing site. Distinct from deploy.yml,
-# which only fires on push to main and pushes the built bundle to
-# GitHub Pages — this workflow runs on every PR (and every push to
-# main, as a safety net) so a broken Astro build or a TypeScript
-# regression in the layout / config / structured-data fails review
-# before it ever reaches the deploy step.
 name: CI
+
+# The jobs live in FireBall1725/workflows. This site does not version and does
+# not release: merging to main is shipping, so CI is the only gate.
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - run: npm ci
-
-      # `astro check` runs the @astrojs/check type pass over .astro and
-      # .ts files plus the config. Catches things `astro build` doesn't
-      # — wrong prop types, structured-data shape errors, missing
-      # imports — without spinning up the full Vite build.
-      - run: npm run check
-
-      - run: npm run build
+  ci:
+    uses: FireBall1725/workflows/.github/workflows/ci-astro.yml@v1


### PR DESCRIPTION
Puts this site on [FireBall1725/workflows](https://github.com/FireBall1725/workflows): `npm ci`, `astro check`, `npm run build`, and the shared editorconfig gate on every PR.

The site deploys on merge, so a build that only fails at deploy time fails after it is meant to be live. No release workflow pairs with this: these sites don't version, and merging to main is shipping.