### PR TITLE
Run CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+# Free on public repos, and this one is public. Every other public repo in the
+# fleet runs it; a repo without it is an oversight rather than a decision.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '31 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Every public repo in the fleet runs CodeQL; this one was missed. Caught by the extended `check-alignment.sh`.

`firebin-kicad`, `firebin-site`, and `fireball1725-ca` also show `NO-CODEQL`, but all three are private, where CodeQL isn't free. That's a billing constraint rather than an oversight.